### PR TITLE
fixed(navigation): propagate options to navigate function.

### DIFF
--- a/src/withRouter/effects.js
+++ b/src/withRouter/effects.js
@@ -1,7 +1,7 @@
 import { navigate } from './lib/navigate';
 
-const NavigateFX = (_dispatch, href) => {
-  navigate(href);
+const NavigateFX = (_dispatch, { href, options }) => {
+  navigate(href, options);
 };
 export const Navigate = props => [
   NavigateFX,


### PR DESCRIPTION
Fixes #4.

This patch fixes the propagations of the options  to the `navigate` function.

```js
const redirect = href => Navigate({ href, options: { type: 'replace' } })
```

Please, let me know if there is something I'm missing.

Thanks.